### PR TITLE
API: upgrade dependencies and add ETHERSCAN_API_URL 

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -8,6 +8,7 @@ from flask import Flask, jsonify
 from flask_cors import CORS
 
 PORT = 3000
+ETHERSCAN_API_URL = 'https://api.etherscan.io/api'
 ETHERSCAN_API_KEY = '6H8VRTDHJVS6II983YY3DN8NCVBBHDA3MX' # should be env var, but whatever
 SOLIDITY_TO_BQ_TYPES = {
   'address': 'STRING',
@@ -137,7 +138,7 @@ table_description = ''
 def read_abi_from_address(address):
   a = address.lower()
   k = ETHERSCAN_API_KEY
-  url = f'https://api.etherscan.io/api?module=contract&action=getabi&address={a}&apikey={k}'
+  url = f'{ETHERSCAN_API_URL}?module=contract&action=getabi&address={a}&apikey={k}'
   json_response = get(url).json()
   return loads(json_response['result'])
 
@@ -145,7 +146,7 @@ def read_contract(contract):
   if contract is not None and contract.startswith('0x'):
     a = contract.lower()
     k = ETHERSCAN_API_KEY
-    url = f'https://api.etherscan.io/api?module=contract&action=getsourcecode&address={a}&apikey={k}'
+    url = f'{ETHERSCAN_API_URL}?module=contract&action=getsourcecode&address={a}&apikey={k}'
     json_response = get(url).json()
     contract = [x for x in json_response['result'] if 'ContractName' in x][0]
     return contract

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,7 @@
 eth-utils==1.8.1
-MarkupSafe==1.1.1
-Jinja2==2.10.3
+MarkupSafe==2.1.1
+Jinja2==3.1.2
 pysha3==1.0.2
-Flask==1.1.1
-Flask-Cors==3.0.8
+Flask==3.0.0
+Flask-Cors==4.0.0
 requests==2.22.0


### PR DESCRIPTION
This PR adds 2 main features:
- upgrade Pypi dependencies
- add ETHERSCAN_API_URL to make the project network agnostic and work on any etherscan implementation